### PR TITLE
feat: add docker compose to launch mongo db

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # CollabJam-Server
+
+## Setup MongoDB
+
+To use the server you need a MongoDB server running. You can install the server locally or use the docker compose configuration from the repository by executing:
+
+```
+docker compose up
+```
+
+This also launches a Mongo Express instance on `http://localhost:8081` to inspect the database.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+volumes:
+  mongodata:
+
+services:
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodata:/data/db
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://mongo:27017/
+      ME_CONFIG_BASICAUTH: false


### PR DESCRIPTION
A small convenience feature for people that do not want to install and configure a mongo db server on their system.